### PR TITLE
Employers can now invite past helpers to their open jobs

### DIFF
--- a/app/imports/ui/components/EmployeeCard.jsx
+++ b/app/imports/ui/components/EmployeeCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Image, Button, Label } from 'semantic-ui-react';
+import { Card, Image, Button, Label, Dropdown, Grid } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import StarRating from './StarRating';
 import { Jobs } from '../../api/jobs/jobs';
@@ -7,7 +7,11 @@ import { Jobs } from '../../api/jobs/jobs';
 export default class EmployeeCard extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      selectedJobID: '',
+    };
     this.handleHireHelper = this.handleHireHelper.bind(this);
+    this.handleChange = this.handleChange.bind(this);
   }
 
   handleHireHelper() {
@@ -29,13 +33,27 @@ export default class EmployeeCard extends React.Component {
     );
   }
 
+  handleChange(event, data) {
+    console.log(data.value);
+    this.setState({
+      selectedJobID: data.value,
+    });
+  }
+
   render() {
-    const { employee, cardType, skills, ratings } = this.props;
+    const { employee, cardType, skills, ratings, jobs, inviteHelperCallback } = this.props;
+    const { selectedJobID } = this.state;
     const skillObjects = employee.profile.skills.map((skillId) => skills.find((skill) => skill.key === skillId));
     const skillNames = skillObjects.map((skill) => skill.text);
     const ratingValues = ratings.map((rating) => rating.rating);
     const ratingSum = ratingValues.reduce((acc, value) => acc + value, 0);
     const aveRating = ratingSum / ratings.length;
+    let jobInviteSelections;
+    if (cardType === 'feedback') {
+      jobInviteSelections = jobs.filter((job) => job.open === 1).map(function (job) {
+        return { key: job._id, text: job.title, value: job._id };
+      });
+    }
     return (
       <Card>
         <Card.Content>
@@ -57,9 +75,19 @@ export default class EmployeeCard extends React.Component {
         <Card.Content extra>
           {
             cardType === 'feedback' &&
-            <div className='ui one buttons'>
-              <Button basic color='green'>Invite To a Job</Button>
-            </div>
+            <Grid container rows={2}>
+              <Grid.Row>
+              <Dropdown placeholder='Invite to a Job' selection
+                        options={jobInviteSelections}
+                        onChange={this.handleChange}></Dropdown>
+              </Grid.Row>
+              <Grid.Row>
+              <div className='ui one buttons'>
+                <Button basic color='green'
+                        onClick={() => inviteHelperCallback(selectedJobID, employee)}>Invite To a Job</Button>
+              </div>
+              </Grid.Row>
+            </Grid>
           }
           {
             cardType === 'hire' &&
@@ -80,4 +108,6 @@ EmployeeCard.propTypes = {
   handleSuccessHire: PropTypes.func,
   skills: PropTypes.array,
   ratings: PropTypes.array,
+  inviteHelperCallback: PropTypes.func,
+  jobs: PropTypes.array,
 };

--- a/app/imports/ui/components/EmployerLanding.jsx
+++ b/app/imports/ui/components/EmployerLanding.jsx
@@ -16,26 +16,6 @@ import { JobApplicants } from '../../api/jobApplicants/jobApplicants';
 import { Categories } from '../../api/categories/categories';
 import { Ratings } from '../../api/ratings/ratings';
 
-/*
-const pastHelpers = [
-  {
-    _id: 1,
-    firstName: 'Steve',
-    lastName: 'Sanders',
-    aveRating: 3,
-    skills: ['Handy Man', 'Landscaping'],
-    profileImg: '/images/landingPage/student1.jpg',
-  },
-  {
-    _id: 1,
-    firstName: 'Julie',
-    lastName: 'Sanders',
-    aveRating: 4,
-    skills: ['Transporting'],
-    profileImg: '/images/landingPage/student3.jpeg',
-  },
-];
-*/
 class EmployerLanding extends React.Component {
   constructor(props) {
     super(props);
@@ -75,6 +55,7 @@ class EmployerLanding extends React.Component {
     this.submitRating = this.submitRating.bind(this);
     this.handleRatingChange = this.handleRatingChange.bind(this);
     this.handleSuccessEmployeeHire = this.handleSuccessEmployeeHire.bind(this);
+    this.handleInviteHelper = this.handleInviteHelper.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -265,6 +246,30 @@ class EmployerLanding extends React.Component {
     });
   }
 
+  handleInviteHelper(jobID, helper) {
+    // updates on the client side need the _id of the document to be updated
+    // jobId is not sufficient and results in an untrusted 403 error
+    const applicantDoc = JobApplicants.findOne({ jobId: jobID });
+
+    JobApplicants.update(
+        {
+          _id: applicantDoc._id,
+        },
+        {
+          $addToSet: { applicantIds: helper.username },
+        },
+        (err, success) => {
+          if (err === null && success !== null) {
+            Bert.alert(`Successfully invited helper ${helper.username}`, 'success', 'growl-top-right');
+          }
+          else {
+            Bert.alert('Failed to invite helper', 'danger', 'growl-top-right');
+          }
+        },
+    );
+    this.setState(this.state); // forces a re-render of the page to show the updated job card state
+  }
+
   renderPage() {
     const { skills, categories } = this.props;
 
@@ -309,7 +314,8 @@ class EmployerLanding extends React.Component {
                   filteredHelpers.map((helper, index) =>
                       <EmployeeCard key={index} employee={helper}
                                     ratings={this.props.ratings.filter((rating) => rating.user === helper.username)}
-                                    skills={skills} cardType='feedback'/>)
+                                    skills={skills} jobs={jobs}
+                                    inviteHelperCallback={this.handleInviteHelper} cardType='feedback'/>)
                 }
               </Card.Group>
             </Grid.Row>


### PR DESCRIPTION
I have implemented the functionality allowing Employers to invite their past helpers to their open jobs. A dropdown was added to the `EmployeeCard` allowing the employer to select which job to invite the employee to. Pressing the invite button triggers a callback in the `EmployerLanding` page that does an update on the `JobApplicants` collection, adding the employee to the set of applicants for the chosen job. The callback also triggers a re-rendering of the page using `this.setState(this.state)` to cause the Hire Helper button to appear enabled as soon as the invited helper is added as an applicant. The update to the applicants collection uses `$addToSet` to insert the username of the invited employee into the applicants array, which ensures by mathematical Set semantics that the same employee cannot be added as an applicant to a given job more than once. Later, we can run a cross check query on the `JobApplicants` collection to only display as options the open jobs for which the selected helper is not already an applicant. However, as of right now, the required functionality has been tested and is working properly.

resolves #82 