### PR TITLE
Fixed bug in EmployerJobCard

### DIFF
--- a/app/imports/ui/components/EmployerJobCard.jsx
+++ b/app/imports/ui/components/EmployerJobCard.jsx
@@ -24,7 +24,9 @@ class EmployerJobCard extends React.Component {
       }
     });
     const jobApplicant = JobApplicants.findOne({ jobId: job._id });
-    applicantCount = jobApplicant.applicantIds.length;
+    if (jobApplicant !== undefined) {
+      applicantCount = jobApplicant.applicantIds.length;
+    }
     const hireButtonText = (applicantCount === 0) ? 'No Applicants Yet' : 'Hire Helper';
     let status = <p style={{ color: 'blue' }}>OPEN</p>;
     let cardColor = 'blue';

--- a/app/imports/ui/components/EmployerLanding.jsx
+++ b/app/imports/ui/components/EmployerLanding.jsx
@@ -271,10 +271,10 @@ class EmployerLanding extends React.Component {
   }
 
   renderPage() {
-    const { skills, categories } = this.props;
+    const { skills, categories, jobs } = this.props;
 
     const {
-      jobs, jobModalOpen, newJob, skillSearchQuery,
+      jobModalOpen, newJob, skillSearchQuery,
       formError, categorySearchQuery, feedbackModalOpen, userToRate, ratingValue,
       hireModalOpen, openedJob } = this.state;
     const pastHelperNames = jobs.filter((job) => job.open === 2).map((job) => job.employeeId);


### PR DESCRIPTION
There is a conditional that checks to make sure that the jobApplicant object is defined before attempting to access its id. We can now create new jobs on the EmployerLanding without triggering an error upon re-render.

resolves #102 