### PR TITLE
Fixed rendering of Job Selection Dropdown on Employee Card

### DIFF
--- a/app/imports/ui/components/EmployeeCard.jsx
+++ b/app/imports/ui/components/EmployeeCard.jsx
@@ -77,7 +77,7 @@ export default class EmployeeCard extends React.Component {
             cardType === 'feedback' &&
             <Grid container rows={2}>
               <Grid.Row>
-              <Dropdown placeholder='Invite to a Job' selection
+              <Dropdown placeholder='Invite to a Job' selection upward
                         options={jobInviteSelections}
                         onChange={this.handleChange}></Dropdown>
               </Grid.Row>


### PR DESCRIPTION
The dropdown now has the upward property so that the list of Jobs renders on the window, instead of going  behind the footer.